### PR TITLE
Introducing IReadValueDescriptor, IWriteValueDescriptor.

### DIFF
--- a/IEnumProcessor.cs
+++ b/IEnumProcessor.cs
@@ -13,11 +13,10 @@ namespace GraphClimber
         /// <typeparam name="TEnum">The type of the enum</typeparam>
         /// <typeparam name="TUnderlying">The underlying type of the enum</typeparam>
         /// <remarks>
-        /// It is safe to cast the given <paramref name="value"/> to <typeparamref name="TUnderlying"/>
+        /// It is safe to cast the given <see cref="descriptor"/>.<see cref="IReadValueDescriptor{TRuntime}.Get"/> to <typeparamref name="TUnderlying"/>
         /// </remarks>
-        /// <param name="value"></param>
         /// <param name="descriptor"></param>
-        void Process<TEnum, TUnderlying>(TEnum value, IValueDescriptor<TEnum> descriptor);
+        void Process<TEnum, TUnderlying>(IReadWriteValueDescriptor<TEnum> descriptor);
 
         /// <summary>
         /// Processes an enumeration value that is boxed inside an object
@@ -25,11 +24,10 @@ namespace GraphClimber
         /// <typeparam name="TEnum">The type of the enum</typeparam>
         /// <typeparam name="TUnderlying">The underlying type of the enum</typeparam>
         /// <remarks>
-        /// It is safe to cast the given <paramref name="value"/> to <typeparamref name="TUnderlying"/>
+        /// It is safe to cast the given <see cref="descriptor"/>.<see cref="IReadValueDescriptor{TRuntime}.Get"/> to <typeparamref name="TUnderlying"/>
         /// </remarks>
-        /// <param name="value"></param>
         /// <param name="descriptor"></param>
-        void Process<TEnum, TUnderlying>(TEnum value, IValueDescriptor<object> descriptor);
-
+        /// TODO: reundant: IReadWriteValueDescriptor<TEnum> is already IReadWriteValueDescriptor<TEnum, object>.
+        void Process<TEnum, TUnderlying>(IReadWriteValueDescriptor<TEnum, object> descriptor);
     }
 }

--- a/IInheritedProcessor.cs
+++ b/IInheritedProcessor.cs
@@ -1,15 +1,49 @@
 ﻿namespace GraphClimber
 {
     /// <summary>
-    /// Defines an actor that can process values that are 
+    /// Defines an actor that can process read values that are 
     /// of type <typeparamref name="TField"/> or descendents
     /// of that type.
     /// </summary>
     /// <typeparam name="TField"></typeparam>
-    public interface IInheritedProcessor<TField>
+    public interface IReadProcessor<in TField>
     {
-        void Process<TReal>(TReal value, IValueDescriptor<TField> descriptor)
-            where TReal : TField;
+        void ProcessForRead(IReadValueDescriptor<TField> descriptor);
+    }
 
+    /// <summary>
+    /// Defines an actor that can process values that are 
+    /// of static type <typeparamref name="TField"/> or less 
+    /// </summary>
+    /// <typeparam name="TField"></typeparam>
+    /// <remarks>
+    /// Example: Set all fields that their static type is 
+    /// assignable from IEnumerable{char} to string.Empty.
+    /// This includes object and IEnumerable, IEnumerable{string}.
+    /// </remarks>
+    public interface IWriteProcessor<out TField>
+    {
+        void ProcessForWrite(IWriteValueDescriptor<TField> descriptor);
+    }
+
+    /// <summary>
+    /// Defines an actor that can process values that are 
+    /// of runtime type <typeparamref name="TRuntime"/> and static type <typeparamref name="TField"/>.
+    /// </summary>
+    /// <typeparam name="TField"></typeparam>
+    /// <typeparam name="TRuntime"></typeparam>
+    public interface IReadWriteProcessor<in TField, out TRuntime>
+    {
+        void ProcessForReadWrite(IReadWriteValueDescriptor<TField, TRuntime> descriptor);
+    }
+
+    /// <summary>
+    /// Defines an actor that can process values that are 
+    /// of both runtime and static type <typeparamref name="TField"/>.
+    /// </summary>
+    /// <typeparam name="TField"></typeparam>
+    public interface IReadWriteProcessor<TField>
+    {
+        void ProcessForReadWrite(IReadWriteValueDescriptor<TField> descriptor);
     }
 }

--- a/IProcessor.cs
+++ b/IProcessor.cs
@@ -8,14 +8,11 @@ namespace GraphClimber
     /// <typeparam name="TField"></typeparam>
     public interface IProcessor<TField>
     {
-
         /// <summary>
         /// A method that will be called when a value of type <typeparamref name="TField"/>
         /// is found within the graph climbed.
         /// </summary>
-        /// <param name="value"></param>
         /// <param name="descriptor"></param>
-        void Process(TField value, IValueDescriptor<TField> descriptor);
-
+        void ProcessForReadWrite(IReadWriteValueDescriptor<TField> descriptor);
     }
 }

--- a/IRevisitedProcessor.cs
+++ b/IRevisitedProcessor.cs
@@ -6,16 +6,11 @@ namespace GraphClimber
     /// </summary>
     public interface IRevisitedProcessor : IRevisitedFilter
     {
-
         /// <summary>
         /// Called in case that a object is already visited.
         /// </summary>
         /// <typeparam name="TField"></typeparam>
-        /// <typeparam name="TReal"></typeparam>
-        /// <param name="value"></param>
         /// <param name="descriptor"></param>
-        void ProcessRevisited<TField, TReal>(TReal value, IValueDescriptor<TField> descriptor)
-            where TReal : TField;
-
+        void ProcessRevisited<TField>(IReadValueDescriptor<TField> descriptor);
     }
 }

--- a/IValueDescriptor.cs
+++ b/IValueDescriptor.cs
@@ -1,31 +1,14 @@
 namespace GraphClimber
 {
-
-
     /// <summary>
     /// Represents a description for a value of type
-    /// <typeparamref name="TField"/>
     /// </summary>
-    /// <typeparam name="TField"></typeparam>
-    public interface IValueDescriptor<TField>
+    public interface IValueDescriptor
     {
-
         /// <summary>
         /// Gets the state member that owns the value
         /// </summary>
         IStateMember StateMember { get; }
-
-        /// <summary>
-        /// Sets the field to a new value
-        /// </summary>
-        /// <param name="value"></param>
-        void Set(TField value);
-
-        /// <summary>
-        /// Gets the current value of the field
-        /// </summary>
-        /// <returns></returns>
-        TField Get();
 
         /// <summary>
         /// Gets the owner of the field
@@ -36,6 +19,57 @@ namespace GraphClimber
         /// Climbs on the (current) value that found on the owner.
         /// </summary>
         void Climb();
+    }
 
+    /// <remarks>
+    /// Allows processing state member values based on their RuntimeType:
+    /// Used mostly for serialization.
+    /// </remarks>
+    public interface IReadValueDescriptor<out TRuntime> : IValueDescriptor
+    {
+        /// <summary>
+        /// Gets the current value of the field
+        /// </summary>
+        /// <returns></returns>
+        TRuntime Get();         
+    }
+
+    /// <remarks>
+    /// Allows processing state member values based on their static type:
+    /// Used mostly for deserialization.
+    /// </remarks>
+    public interface IWriteValueDescriptor<in TField> : IValueDescriptor
+    {
+        /// <summary>
+        /// Sets the field to a new value
+        /// </summary>
+        /// <param name="value"></param>
+        void Set(TField value);         
+    }
+
+    /// <remarks>
+    /// Allows processing state member values based on both static and runtime types.
+    /// </remarks>
+    /// <example>
+    /// IReadWriteValueDescriptor{IEnumerable{string}, ICollection{string}} represents
+    /// state members that have static type that is at most IEnumerable{string}, but 
+    /// runtime type that is at least ICollection{string}.
+    /// </example>
+    public interface IReadWriteValueDescriptor<out TField, in TRuntime> :
+        IReadValueDescriptor<TField>, IWriteValueDescriptor<TRuntime>
+    {
+    }
+
+    /// <remarks>
+    /// Allows processing state member values based on both static and runtime types.
+    /// </remarks>
+    /// <example>
+    /// IReadWriteValueDescriptor{IEnumerable{string}, ICollection{string}} represents
+    /// state members that have static type that is at most IEnumerable{string}, but 
+    /// runtime type that is at least ICollection{string}.
+    /// </example>
+    public interface IReadWriteValueDescriptor<TField> :
+        IReadWriteValueDescriptor<TField, TField>
+    {
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -17,16 +17,18 @@ namespace GraphClimber
 
     }
 
-    public class MyInheritedProcessor : IInheritedProcessor<IAsyncResult>, IProcessor<int[]>, IRevisitedFilter
+    public class MyInheritedProcessor : IWriteProcessor<IAsyncResult>, IProcessor<int[]>, IRevisitedFilter
     {
-
-        public void Process<TReal>(TReal value, IValueDescriptor<IAsyncResult> descriptor) where TReal : IAsyncResult
+        public void ProcessForWrite(IWriteValueDescriptor<IAsyncResult> descriptor)
         {
+            // Sets all fields that are assignable from IAsyncResult to null.
+            // (i.e: all fields that have static type object or IAsyncResult)
             descriptor.Set((IAsyncResult)null);
         }
 
-        public void Process(int[] value, IValueDescriptor<int[]> descriptor)
+        public void ProcessForReadWrite(IReadWriteValueDescriptor<int[]> descriptor)
         {
+            int[] value = descriptor.Get();
             value[0] = 4;
             descriptor.Set(value);
         }
@@ -34,6 +36,16 @@ namespace GraphClimber
         public bool Visited(object obj)
         {
             return false;
+        }
+    }
+
+    public class MyInheritedProcessor2 : IReadWriteProcessor<IAsyncResult>
+    {
+        public void ProcessForReadWrite(IReadWriteValueDescriptor<IAsyncResult> descriptor)
+        {
+            // Sets all field that are assignable from IAsyncResult and are
+            // actually currently from type IAsyncResult, to null.
+            descriptor.Set((IAsyncResult)null);
         }
     }
 }


### PR DESCRIPTION
I think it is better to distinguish the usages of this library: for serialization we care mostly of the runtime type of the value, for deserialization we care mostly for the static type of its field.

Here is my suggestion, feel free to do whatever you want with it.
