### PR TITLE
Climb() : Added Processor Argument

### DIFF
--- a/src/GraphClimber/Program.cs
+++ b/src/GraphClimber/Program.cs
@@ -108,15 +108,11 @@ namespace GraphClimber
         [ProcessorMethod(Precedence = 102)]
         public void ProcessGeneric<T>(IWriteOnlyValueDescriptor<T> descriptor)
         {
-            XElement temp = _reader;
-
-            _reader = _reader.Element(descriptor.StateMember.Name);
+            var innerReader = _reader.Element(descriptor.StateMember.Name);
 
             CreateObject(descriptor);
 
-            descriptor.Climb();
-
-            _reader = temp;
+            descriptor.Climb(new XmlReaderProcessor(innerReader));
         }
 
         private void CreateObject<T>(IWriteOnlyValueDescriptor<T> descriptor) 
@@ -152,7 +148,7 @@ namespace GraphClimber
                 // TODO: this will be the route method..
                 descriptor.Route
                     (new MyCustomStateMember((IReflectionStateMember) descriptor.StateMember,
-                        instanceType), descriptor.Owner);
+                        instanceType), descriptor.Owner, this);
             }
         }
 
@@ -243,7 +239,7 @@ namespace GraphClimber
         {
             WritePropertyName(descriptor);
 
-            descriptor.Climb();
+            descriptor.Climb(this);
 
             EndWritePropertyName();
         }

--- a/src/GraphClimber/ValueDescriptor/IValueDescriptor.cs
+++ b/src/GraphClimber/ValueDescriptor/IValueDescriptor.cs
@@ -20,10 +20,11 @@ namespace GraphClimber
         /// <summary>
         /// Climbs on the (current) value that found in the field by the owner
         /// </summary>
-        void Climb();
+        /// <param name="processor"></param>
+        void Climb(object processor);
 
-        void Route(IStateMember stateMember, Type runtimeMemberType, object owner);
+        void Route(IStateMember stateMember, Type runtimeMemberType, object owner, object processor);
 
-        void Route(IStateMember stateMember, object owner);
+        void Route(IStateMember stateMember, object owner, object processor);
     }
 }


### PR DESCRIPTION
Hi.

I have a suggestion to add to the Climb() method of the descriptors a processor argument,
It makes the code cleaner when the climb needs to be done with different state.

For example see program.cs:109.
